### PR TITLE
Minor fix: AWS classpath container appearance 

### DIFF
--- a/com.amazonaws.eclipse.sdk.ui/src/com/amazonaws/eclipse/sdk/ui/classpath/AwsClasspathContainer.java
+++ b/com.amazonaws.eclipse.sdk.ui/src/com/amazonaws/eclipse/sdk/ui/classpath/AwsClasspathContainer.java
@@ -35,6 +35,8 @@ import com.amazonaws.eclipse.sdk.ui.JavaSdkInstall;
  */
 public class AwsClasspathContainer implements IClasspathContainer {
 
+	public final static Path ID = new Path("com.amazonaws.eclipse.sdk.AWS_JAVA_SDK");
+	
     /** The SDK containing the libraries to expose on the Java Project classpath */
     private JavaSdkInstall sdkInstall;
 
@@ -56,14 +58,16 @@ public class AwsClasspathContainer implements IClasspathContainer {
     /* (non-Javadoc)
      * @see org.eclipse.jdt.core.IClasspathContainer#getClasspathEntries()
      */
-    public IClasspathEntry[] getClasspathEntries() {
+    @Override
+	public IClasspathEntry[] getClasspathEntries() {
         return loadSdkClasspathEntriesAsArray(sdkInstall);
     }
 
     /**
      * @see org.eclipse.jdt.core.IClasspathContainer#getDescription()
      */
-    public String getDescription() {
+    @Override
+	public String getDescription() {
         return "AWS SDK for Java";
     }
 
@@ -78,15 +82,17 @@ public class AwsClasspathContainer implements IClasspathContainer {
     /**
      * @see org.eclipse.jdt.core.IClasspathContainer#getKind()
      */
-    public int getKind() {
+    @Override
+	public int getKind() {
         return IClasspathContainer.K_APPLICATION;
     }
 
     /**
      * @see org.eclipse.jdt.core.IClasspathContainer#getPath()
      */
-    public IPath getPath() {
-        return new Path("com.amazonaws.eclipse.sdk.AWS_JAVA_SDK");
+    @Override
+	public IPath getPath() {
+        return ID;
     }
 
 

--- a/com.amazonaws.eclipse.sdk.ui/src/com/amazonaws/eclipse/sdk/ui/classpath/AwsClasspathContainerPage.java
+++ b/com.amazonaws.eclipse.sdk.ui/src/com/amazonaws/eclipse/sdk/ui/classpath/AwsClasspathContainerPage.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.ui.wizards.IClasspathContainerPage;
 import org.eclipse.jdt.ui.wizards.IClasspathContainerPageExtension;
 import org.eclipse.jface.resource.ImageRegistry;
@@ -52,6 +53,7 @@ public class AwsClasspathContainerPage extends WizardPage
 	/**
 	 * @see org.eclipse.jface.dialogs.IDialogPage#createControl(org.eclipse.swt.widgets.Composite)
 	 */
+	@Override
 	public void createControl(Composite parent) {
 	    JavaSdkInstall currentSdk = null;
 	    try {
@@ -69,6 +71,7 @@ public class AwsClasspathContainerPage extends WizardPage
 		this.setControl(sdkVersionInfoComposite);
 	}
 	
+	@Override
 	public boolean finish() {
 	    try {
 	        SdkProjectMetadata sdkProjectMetadataFile = new SdkProjectMetadata(project.getProject());
@@ -88,6 +91,7 @@ public class AwsClasspathContainerPage extends WizardPage
 	/**
 	 * @see org.eclipse.jdt.ui.wizards.IClasspathContainerPageExtension#initialize(org.eclipse.jdt.core.IJavaProject, org.eclipse.jdt.core.IClasspathEntry[])
 	 */
+	@Override
 	public void initialize(IJavaProject project, IClasspathEntry[] currentEntries) {
 	    this.project = project;
 	}
@@ -95,13 +99,15 @@ public class AwsClasspathContainerPage extends WizardPage
 	/**
 	 * @see org.eclipse.jdt.ui.wizards.IClasspathContainerPage#getSelection()
 	 */
+	@Override
 	public IClasspathEntry getSelection() {
-	    return null;
+	    return JavaCore.newContainerEntry(AwsClasspathContainer.ID);
 	}
 
 	/**
 	 * @see org.eclipse.jdt.ui.wizards.IClasspathContainerPage#setSelection(org.eclipse.jdt.core.IClasspathEntry)
 	 */
+	@Override
 	public void setSelection(IClasspathEntry containerEntry) {}
 
 }


### PR DESCRIPTION
If you override the IClasspathContainerPage class's getSelection() method, then after the selection of the AWS classpath container, itt will occures in the Jaba Build Path - Libraries panel.
It's the solution for Issue #7 .

(Sry for the override annotations, im not sure you want to use them... ) 
