### PR TITLE
Enable the display of the cursor line and column position in the status ...

### DIFF
--- a/com.amazonaws.eclipse.cloudformation/plugin.xml
+++ b/com.amazonaws.eclipse.cloudformation/plugin.xml
@@ -47,6 +47,7 @@
              extensions="template,cftemplate"
              icon="icons/stack.png"
              id="com.amazonaws.eclipse.explorer.cloudformation.templateEditor"
+             contributorClass="org.eclipse.ui.texteditor.BasicTextEditorActionContributor"
              name="Amazon CloudFormation Template Editor">
      </editor>
   </extension>


### PR DESCRIPTION
...bar below the text editor. Only modifies the template editor as I have never used the stack editor. Tested with Eclipse Kepler 4.3.2. Causes the template editor to display the current line number (and some other editing related information) like this:

![image](https://f.cloud.github.com/assets/3304436/2319325/1ff4ae5c-a37b-11e3-8800-93167157e3c2.png)
