### PR TITLE
S3ObjectSummaryTable incorrectly displays keys with colons #74

### DIFF
--- a/bundles/com.amazonaws.eclipse.core/src/com/amazonaws/eclipse/explorer/s3/S3ObjectSummaryTable.java
+++ b/bundles/com.amazonaws.eclipse.core/src/com/amazonaws/eclipse/explorer/s3/S3ObjectSummaryTable.java
@@ -557,7 +557,7 @@ public class S3ObjectSummaryTable extends Composite {
 
                 int i = filteredObjectSummaries.size();
                 for ( String commonPrefix : filteredCommonPrefixes ) {
-                    objects[i++] = new Path(commonPrefix);
+                    objects[i++] = new Path(null, commonPrefix);
                 }
 
                 children.put(treePath, objects);


### PR DESCRIPTION
The display won't be 100% accurate to S3, but at least it won't be truncated output.