### PR TITLE
Lambda S3 Logs Correction. It was printing bucket name instead of obj…

### DIFF
--- a/bundles/com.amazonaws.eclipse.lambda/code-template/lambda/s3-get-object/handler.java.ftl
+++ b/bundles/com.amazonaws.eclipse.lambda/code-template/lambda/s3-get-object/handler.java.ftl
@@ -37,7 +37,7 @@ public class ${handlerClassName} implements RequestHandler<S3Event, String> {
             e.printStackTrace();
             context.getLogger().log(String.format(
                 "Error getting object %s from bucket %s. Make sure they exist and"
-                + " your bucket is in the same region as this function.", bucket, key));
+                + " your bucket is in the same region as this function.", key, bucket));
             throw e;
         }
     }


### PR DESCRIPTION
Lambda S3 Logs Correction. It was printing bucket name instead of object name. #77 