### PR TITLE
Fixed New AWS Java Web Project SWT error.

### DIFF
--- a/bundles/com.amazonaws.eclipse.elasticbeanstalk/src/com/amazonaws/eclipse/elasticbeanstalk/webproject/JavaWebProjectWizardPage.java
+++ b/bundles/com.amazonaws.eclipse.elasticbeanstalk/src/com/amazonaws/eclipse/elasticbeanstalk/webproject/JavaWebProjectWizardPage.java
@@ -114,7 +114,8 @@ final class JavaWebProjectWizardPage extends WizardPage {
 
         Group group = new Group(composite, SWT.NONE);
         group.setLayoutData(layoutData);
-        group.setLayout(new FillLayout());
+//        group.setLayout(new FillLayout());
+        group.setLayout(new GridLayout());
         accountSelectionComposite = new AccountSelectionComposite(group, SWT.None);
 
         dataModel.setAccountId(AwsToolkitCore.getDefault().getCurrentAccountId());

--- a/releng/com.amazonaws.eclipse.devide/.project
+++ b/releng/com.amazonaws.eclipse.devide/.project
@@ -3,6 +3,14 @@
 	<name>com.amazonaws.eclipse.devide</name>
 	<comment></comment>
 	<projects>
+		<project>aws-toolkit-eclipse</project>
+		<project>com.amazonaws.eclipse.core</project>
+		<project>com.amazonaws.eclipse.core.feature</project>
+		<project>com.amazonaws.eclipse.elasticbeanstalk</project>
+		<project>com.amazonaws.eclipse.elasticbeanstalk.feature</project>
+		<project>com.amazonaws.eclipse.javasdk</project>
+		<project>com.amazonaws.eclipse.oxygen</project>
+		<project>com.amazonaws.eclipse.sdk.ui</project>
 	</projects>
 	<buildSpec>
 		<buildCommand>

--- a/releng/com.amazonaws.eclipse.devide/category.xml
+++ b/releng/com.amazonaws.eclipse.devide/category.xml
@@ -14,5 +14,5 @@
    <feature id="org.eclipse.wst.common.fproj.sdk" version="0.0.0"/>
    <feature id="org.eclipse.wst.web_sdk.feature" version="0.0.0"/>
    <feature id="org.eclipse.wst.server_adapters.sdk.feature" version="0.0.0"/>
-   <bundle id="com.amazonaws.eclipse.javasdk" version="1.11.130"/>
+   <bundle id="com.amazonaws.eclipse.javasdk" version="1.11.248"/>
 </site>

--- a/tests/com.amazonaws.eclipse.core.tests/src/com/amazonaws/eclipse/core/regions/RegionUtilsTest.java
+++ b/tests/com.amazonaws.eclipse.core.tests/src/com/amazonaws/eclipse/core/regions/RegionUtilsTest.java
@@ -15,7 +15,7 @@ public class RegionUtilsTest {
         // s3 irregular regional endpoints
         Pattern.compile("^(http|https)://s3-(us|eu|ap|sa)-(gov-)?(east|west|south|north|central|northeast|southeast)-(1|2).amazonaws.com(/)?$"),
         // regular region endpoints
-        Pattern.compile("^(http|https)://\\w+\\.(\\w+\\.)?(ca|us|eu|ap|sa)-(gov-)?(east|west|south|north|central|northeast|southeast)-(1|2)\\.amazonaws\\.com(/)?$"),
+        Pattern.compile("^(http|https)://\\w+\\.(\\w+\\.)?(ca|us|eu|ap|sa)-(gov-)?(east|west|south|north|central|northeast|southeast)-(1|2|3)\\.amazonaws\\.com(/)?$"),
         // China region endpoints, currently we only have cn-north-1 region
         Pattern.compile("^(http|https)://\\w+\\.(\\w+\\.)?cn-(north|northwest)-1.amazonaws.com.cn(/)?$"),
         // us-gov region endpoints

--- a/thirdparty/com.amazonaws.eclipse.javasdk/META-INF/MANIFEST.MF
+++ b/thirdparty/com.amazonaws.eclipse.javasdk/META-INF/MANIFEST.MF
@@ -195,10 +195,10 @@ Export-Package: com.amazonaws.services.codedeploy,com.amazonaws.servic
 Bundle-SymbolicName: com.amazonaws.eclipse.javasdk
 Bundle-Name: AWS Toolkit for Eclipse Java SDK Bundle
 Bundle-Version: 1.11.248
-Built-By: zhaoxiz
+Built-By: dmainz
 Bundle-ManifestVersion: 2
-Bnd-LastModified: 1513292086530
+Bnd-LastModified: 1514212585795
 Created-By: Apache Maven Bundle Plugin
 Tool: Bnd-0.0.357
-Build-Jdk: 1.8.0_151
+Build-Jdk: 1.8.0_40
 


### PR DESCRIPTION
Fixed org.eclipse.swt.layout.GridData cannot be cast to org.eclipse.swt.layout.FillData error in com/amazonaws/eclipse/elasticbeanstalk/webproject/JavaWebProjectWizardPage.java when user selects New AWS Java Web Project.  Fixed assertion error on Maven test for eu-west-3.  Fixed wrong AWS SDK version being specified in Maven build.