### PR TITLE
Fix ZipUtilsTest.canUnpackAZipFileToDirectory on Windows

### DIFF
--- a/tests/com.amazonaws.eclipse.opsworks.tests/src/com/amazonaws/eclipse/opsworks/deploy/util/ZipUtilsTest.java
+++ b/tests/com.amazonaws.eclipse.opsworks.tests/src/com/amazonaws/eclipse/opsworks/deploy/util/ZipUtilsTest.java
@@ -40,7 +40,7 @@ public class ZipUtilsTest {
         unzipFileToDirectory(zipFile, target);
 
         Map<String, String> actual = Files.walk(target.toPath()).filter(p -> p.toFile().isFile()).collect(Collectors.toMap(p -> target.toPath().relativize(p).toString(), this::content));
-        assertEquals("hello foo-bar!", actual.get("foo/bar.txt"));
+        assertEquals("hello foo-bar!", actual.get("foo/bar.txt".replace('/', File.separatorChar)));
         assertEquals("hello baz!", actual.get("baz.txt"));
         assertEquals("hello root!", actual.get("root.txt"));
     }


### PR DESCRIPTION
This PR makes `ZipUtilsTest.canUnpackAZipFileToDirectory()` succeed on Windows. The reason is because of different separator between different Operating Systems.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
