### PR TITLE
Remove redundant version in child POM

### DIFF
--- a/bundles/com.amazonaws.eclipse.cloudformation/pom.xml
+++ b/bundles/com.amazonaws.eclipse.cloudformation/pom.xml
@@ -4,7 +4,6 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>com.amazonaws.eclipse.cloudformation</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <parent>
     <groupId>com.amazonaws.eclipse</groupId>

--- a/bundles/com.amazonaws.eclipse.codecommit/pom.xml
+++ b/bundles/com.amazonaws.eclipse.codecommit/pom.xml
@@ -4,7 +4,6 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>com.amazonaws.eclipse.codecommit</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <parent>
     <groupId>com.amazonaws.eclipse</groupId>

--- a/bundles/com.amazonaws.eclipse.codedeploy/pom.xml
+++ b/bundles/com.amazonaws.eclipse.codedeploy/pom.xml
@@ -4,7 +4,6 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>com.amazonaws.eclipse.codedeploy</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <parent>
     <groupId>com.amazonaws.eclipse</groupId>

--- a/bundles/com.amazonaws.eclipse.codestar/pom.xml
+++ b/bundles/com.amazonaws.eclipse.codestar/pom.xml
@@ -4,7 +4,6 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>com.amazonaws.eclipse.codestar</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <parent>
     <groupId>com.amazonaws.eclipse</groupId>

--- a/bundles/com.amazonaws.eclipse.dynamodb/pom.xml
+++ b/bundles/com.amazonaws.eclipse.dynamodb/pom.xml
@@ -4,7 +4,6 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>com.amazonaws.eclipse.dynamodb</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <parent>
     <groupId>com.amazonaws.eclipse</groupId>

--- a/bundles/com.amazonaws.eclipse.elasticbeanstalk/pom.xml
+++ b/bundles/com.amazonaws.eclipse.elasticbeanstalk/pom.xml
@@ -4,7 +4,6 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>com.amazonaws.eclipse.elasticbeanstalk</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <parent>
     <groupId>com.amazonaws.eclipse</groupId>

--- a/bundles/com.amazonaws.eclipse.identitymanagement/pom.xml
+++ b/bundles/com.amazonaws.eclipse.identitymanagement/pom.xml
@@ -4,7 +4,6 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>com.amazonaws.eclipse.identitymanagement</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <parent>
     <groupId>com.amazonaws.eclipse</groupId>

--- a/bundles/com.amazonaws.eclipse.lambda/pom.xml
+++ b/bundles/com.amazonaws.eclipse.lambda/pom.xml
@@ -4,7 +4,6 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>com.amazonaws.eclipse.lambda</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <parent>
     <groupId>com.amazonaws.eclipse</groupId>

--- a/bundles/com.amazonaws.eclipse.opsworks/pom.xml
+++ b/bundles/com.amazonaws.eclipse.opsworks/pom.xml
@@ -4,7 +4,6 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>com.amazonaws.eclipse.opsworks</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <parent>
     <groupId>com.amazonaws.eclipse</groupId>

--- a/bundles/com.amazonaws.eclipse.rds/pom.xml
+++ b/bundles/com.amazonaws.eclipse.rds/pom.xml
@@ -4,7 +4,6 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>com.amazonaws.eclipse.rds</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <parent>
     <groupId>com.amazonaws.eclipse</groupId>

--- a/bundles/com.amazonaws.eclipse.simpledb/pom.xml
+++ b/bundles/com.amazonaws.eclipse.simpledb/pom.xml
@@ -4,7 +4,6 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>com.amazonaws.eclipse.simpledb</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <parent>
     <groupId>com.amazonaws.eclipse</groupId>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -5,7 +5,6 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>com.amazonaws.eclipse.features</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.0-SNAPSHOT</version>
     <parent>
         <groupId>com.amazonaws.eclipse</groupId>
         <artifactId>com.amazonaws.eclipse.root</artifactId>


### PR DESCRIPTION
This PR fixes Eclipse warnings of duplicate version in child POM, since it is retrieved from the version of the specified parent.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
