### PR TITLE
Correct searching for key in tagsDataModel

### DIFF
--- a/bundles/com.amazonaws.eclipse.ec2/src/com/amazonaws/eclipse/ec2/ui/keypair/KeyPairSelectionTable.java
+++ b/bundles/com.amazonaws.eclipse.ec2/src/com/amazonaws/eclipse/ec2/ui/keypair/KeyPairSelectionTable.java
@@ -91,7 +91,7 @@ public class KeyPairSelectionTable extends SelectionTable {
         listeners.add(listener);
     }
 
-    public synchronized void removeRefreshListener(KeyPairSelectionTable listener) {
+    public synchronized void removeRefreshListener(KeyPairRefreshListener listener) {
         listeners.remove(listener);
     }
 

--- a/bundles/com.amazonaws.eclipse.lambda/src/com/amazonaws/eclipse/explorer/lambda/FunctionTagsTable.java
+++ b/bundles/com.amazonaws.eclipse.lambda/src/com/amazonaws/eclipse/explorer/lambda/FunctionTagsTable.java
@@ -100,7 +100,9 @@ public class FunctionTagsTable extends Composite {
                     .getTags();
             List<String> tagKeysToBeRemoved = new ArrayList<>();
             for (String key : oldTagMap.keySet()) {
-                if (!tagsDataModel.getPairSet().contains(key)) {
+                boolean keyExists = tagsDataModel.getPairSet().stream()
+                        .filter(p -> p.getKey().equals(key)).count() != 0;
+                if (!keyExists) {
                     tagKeysToBeRemoved.add(key);
                 }
             }


### PR DESCRIPTION
This PR fixes warnings of unlikely type in method used.

- The first one was asking `List<Pair>` if it `contains()` a String, it is change to iterate over all pairs and compare their keys with the given one.
- The second one was removing a `KeyPairSelectionTable` from listeners of `KeyPairRefreshListener`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
