### PR TITLE
Update AWS SDK for Java to 1.11.948 to support newer Eclipse runtime of Java 11

### DIFF
--- a/bundles/com.amazonaws.eclipse.core/src/com/amazonaws/eclipse/core/accounts/AwsPluginAccountManager.java
+++ b/bundles/com.amazonaws.eclipse.core/src/com/amazonaws/eclipse/core/accounts/AwsPluginAccountManager.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.UUID;
 
-import org.apache.http.annotation.NotThreadSafe;
+import org.apache.http.annotation.Contract;
 import org.eclipse.jface.preference.IPreferenceStore;
 
 import com.amazonaws.eclipse.core.AccountInfo;
@@ -47,7 +47,7 @@ import com.amazonaws.eclipse.core.ui.preferences.AwsAccountPreferencePage;
  * configured via different ways (e.g. by the Eclipse preference store system,
  * or loaded from the local credentials file).
  */
-@NotThreadSafe
+@Contract (threading = org.apache.http.annotation.ThreadingBehavior.UNSAFE)
 public final class AwsPluginAccountManager {
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <eclipse.target>photon</eclipse.target>
     <toolkit.version>4.8.0-SNAPSHOT</toolkit.version>
-    <java-sdk-bundle-version>1.11.248</java-sdk-bundle-version>
+    <java-sdk-bundle-version>1.11.948</java-sdk-bundle-version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>

--- a/releng/com.amazonaws.eclipse.devide/category.xml
+++ b/releng/com.amazonaws.eclipse.devide/category.xml
@@ -14,7 +14,7 @@
    <feature id="org.eclipse.wst.common.fproj.sdk" version="0.0.0"/>
    <feature id="org.eclipse.wst.web_sdk.feature" version="0.0.0"/>
    <feature id="org.eclipse.wst.server_adapters.sdk.feature" version="0.0.0"/>
-   <bundle id="com.amazonaws.eclipse.javasdk" version="1.11.248"/>
+   <bundle id="com.amazonaws.eclipse.javasdk" version="1.11.948"/>
    <bundle id="org.eclipse.datatools.sqltools.sql" version="1.2.100.201801242337"/>
    <bundle id="org.eclipse.datatools.sqltools.sql.ui" version="1.2.100.201801242337"/>
    <bundle id="org.eclipse.datatools.sqltools.common.ui"/>

--- a/thirdparty/com.amazonaws.eclipse.javasdk/pom.xml
+++ b/thirdparty/com.amazonaws.eclipse.javasdk/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>com.amazonaws.eclipse.javasdk</artifactId>
-  <version>1.11.248</version>
+  <version>1.11.948</version>
   <packaging>bundle</packaging>
 
   <dependencies>

--- a/thirdparty/pom.xml
+++ b/thirdparty/pom.xml
@@ -12,7 +12,7 @@
   </prerequisites>
 
   <properties>
-    <java-sdk-version>1.11.248</java-sdk-version>
+    <java-sdk-version>1.11.948</java-sdk-version>
     <commons-io-version>2.4</commons-io-version>
     <jackson-version>2.6.6</jackson-version>
     <javax.annotation-version>1.3.2</javax.annotation-version>


### PR DESCRIPTION
Newer versions of Eclipse have a mandatory Java 11 runtime, which has broken a number of critical functions in this plugin. Many classes were removed from Java 11 that existed in Java 8. Fortunately, the AWS SDK for Java has already done the hard work of replacing these, which we can take advantage of by updating that dependency. This commit should allow for Java 11 support by this plugin without worrying about exports.

*Issue #, if available:*

#226, #222, #219, and several others. This is relevant for any version of Eclipse that requires JRE 11, such 2020-09 or higher.

*Description of changes:*

I kept this small, it only updates the AWS Java SDK dependency and fixes the one bit of code in the plugin that needed to change.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
