### PR TITLE
Adding CodeGuru Reviewer Action

### DIFF
--- a/.github/workflows/codeguru-reviewer.yml
+++ b/.github/workflows/codeguru-reviewer.yml
@@ -5,7 +5,11 @@
 # https://github.com/aws-samples/aws-codeguru-reviewer-cicd-cdk-sample
 
 name: Analyze with CodeGuru Reviewer
-on: [push]
+on:
+  push:
+    branches:
+      - master
+
 permissions:
     id-token: write
     contents: read

--- a/.github/workflows/codeguru-reviewer.yml
+++ b/.github/workflows/codeguru-reviewer.yml
@@ -1,0 +1,58 @@
+
+# Runs CodeGuru Reviewer on push events,
+# and uploads recommendations to the GitHub Security tab.
+# For information on the setup see:
+# https://github.com/aws-samples/aws-codeguru-reviewer-cicd-cdk-sample
+
+name: Analyze with CodeGuru Reviewer
+on: [push]
+permissions:
+    id-token: write
+    contents: read
+    security-events: write 
+
+jobs:
+  CodeGuruReviewerScan:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Assume IAM Role
+      id: iam-role
+      continue-on-error: true
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        role-to-assume: arn:aws:iam::048169001733:role/GuruGitHubCICDRole
+        aws-region: us-west-2
+
+    - uses: actions/checkout@v2
+      if: steps.iam-role.outcome == 'success'
+      with:
+        fetch-depth: 0
+
+    - name: Set up JDK 1.8
+      if: steps.iam-role.outcome == 'success'
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+
+    - name: Compile
+      if: steps.iam-role.outcome == 'success'
+      run: |
+        ./setup.sh
+        mvn -DskipTests -Pbuild-eclipse clean compile
+        mkdir -p class-files
+        cp -r bundles/com.amazonaws.*/target/classes/* class-files 
+
+    - name: Run CodeGuru Reviewer
+      id: guruscan
+      if: steps.iam-role.outcome == 'success'
+      continue-on-error: true
+      uses: aws-actions/codeguru-reviewer@v1.1
+      with:          
+        s3_bucket: codeguru-reviewer-github-profiler-demo-048169001733-uw2
+        build_path: ./class-files
+
+    - name: Upload review result
+      if: steps.iam-role.outcome == 'success' &&steps.guruscan.outcome == 'success'
+      uses: github/codeql-action/upload-sarif@v1
+      with:
+        sarif_file: codeguru-results.sarif.json


### PR DESCRIPTION
*Description of changes:*
Adds an action to run CodeGuru Reviewer on push events to the master branch.
Example is here: https://github.com/martinschaef/aws-toolkit-eclipse/actions/runs/1559154615
Recommendations will be posted to the GitHub Security tab.

The account is owned by the CodeGuru team. We are in the process of onboarding more teams (e.g., [Smithy](https://github.com/awslabs/smithy/blob/main/.github/workflows/codeguru-reviewer.yml)).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
